### PR TITLE
ci: Remove cache_key calculation

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -38,7 +38,6 @@ runs:
       shell: bash
       env:
         GEM_INPUT: ${{ inputs.gem }}
-        RUBY_INPUT: ${{ inputs.ruby }}
         LATEST_INPUT: ${{ inputs.latest }}
       run: |
         # 🛠️ Setup 🛠️
@@ -50,13 +49,6 @@ runs:
         # the lockfile slows things down a bit, but we should still get most
         # of the benefits of bundler caching.
         rm -f "${dir}/Gemfile.lock"
-
-        echo "cache_key=mri" >> $GITHUB_OUTPUT
-        if [[ "$RUBY_INPUT" == "jruby" ]]; then
-          echo "cache_key=jruby" >> $GITHUB_OUTPUT
-        elif [[ "$RUBY_INPUT" == "truffleruby" ]]; then
-          echo "cache_key=truffleruby" >> $GITHUB_OUTPUT
-        fi
 
         echo "appraisals=false" >> $GITHUB_OUTPUT
 
@@ -87,7 +79,7 @@ runs:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
         bundler-cache: true
-        cache-version: "${{ inputs.ruby }}-${{ steps.setup.outputs.cache_key }}"
+        cache-version: "${{ inputs.ruby }}"
 
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies


### PR DESCRIPTION
Currently we are calculating a cache key using

```
echo “cache_key=mri” >> $GITHUB_OUTPUT
if [[ “$RUBY_INPUT” == “jruby” ]]; then
  echo “cache_key=jruby” >> $GITHUB_OUTPUT
elif [[ “$RUBY_INPUT” == “truffleruby” ]]; then
  echo “cache_key=truffleruby” >> $GITHUB_OUTPUT
fi
```

However in no scenario is any value other than mri determined due to $RUBY_INPUT being jruby-10.0.2.0 etc

As such the variable and it's single usage is removed.